### PR TITLE
Expirement with default url scheme

### DIFF
--- a/next/dependencies.lisp
+++ b/next/dependencies.lisp
@@ -1,2 +1,3 @@
 (ql:quickload :cl-strings)
 (ql:quickload :cl-string-match)
+(ql:quickload :quri)

--- a/next/lisp/document-mode.lisp
+++ b/next/lisp/document-mode.lisp
@@ -51,7 +51,14 @@
 	(|setUrl| (buffer-view buffer) url)))
 
 (defun set-url (input-url)
-  (set-url-buffer input-url *active-buffer*))
+  (let ((url (maybe-add-default-url-scheme input-url)))
+    (set-url-buffer url *active-buffer*)))
+
+(defun maybe-add-default-url-scheme (input-url)
+  (let ((url (quri:uri input-url)))
+    (if (quri:uri-scheme url)
+        input-url
+        (concatenate 'string "http://" input-url ))))
 
 (defun document-mode ()
   "Base mode for interacting with documents"

--- a/next/next.asd
+++ b/next/next.asd
@@ -2,7 +2,7 @@
 ;;;; next.asd
 (defsystem :next
   :serial t
-  :depends-on (:cl-strings :cl-string-match)
+  :depends-on (:cl-strings :cl-string-match :quri)
   :components ((:file "lisp/package")
 	       (:file "lisp/macro")
 	       (:file "lisp/qt")


### PR DESCRIPTION
Hi!

Simple helper to add "http://" if no scheme found in the url.
Probably a good idea to make it configurable and move to parameter.
Added [quri](https://github.com/fukamachi/quri) to dependencies. Used for parsing url. 
Let me know if it's the right direction.