### PR TITLE
Ensure that ~/.next.d exists

### DIFF
--- a/next/lisp/bookmark.lisp
+++ b/next/lisp/bookmark.lisp
@@ -44,4 +44,5 @@
 (define-key document-mode-map (kbd "S-s o")
   (:input-complete set-url bookmark-complete))
 (define-key document-mode-map (kbd "S-s s") #'bookmark-current-page)
+(ensure-directories-exist (uiop:physicalize-pathname #P"~/.next.d/"))
 (initialize-bookmark-db)


### PR DESCRIPTION
Note that on non-macOS Unix, this should actually be in `$XDG_CONFIG_HOME`, not `~`.  But that's a different story.

Fixes #8.