### PR TITLE
assets: fix incorrect spelling of "next" -> "nEXT"

### DIFF
--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -13,7 +13,7 @@
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleExecutable</key>
-    <string>next</string>
+    <string>nEXT</string>
     <key>CFBundleIdentifier</key>
     <string>next.browser</string>
     <key>NSAppTransportSecurity</key>


### PR DESCRIPTION
I found that the binary release didn't work due to the Info.plist not having
the correct case of the binary on the file system. Found by using
case-sensitive APFS.