### PR TITLE
add page zooming functionality

### DIFF
--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -26,6 +26,16 @@ provided.
 
 1. ~C-n~: Move down
 2. ~C-p~: Move up
+3. ~scroll-left~: Move left (no keybindings for now)
+4. ~scroll-right~: Move right (no keybindings for now)
+
+*** Zooming page
+Use the zoom keybindings to make everything on a webpage larger or smaller.
+These keybindings mimic the Emacs counterpart:
+
+1. ~C-x C-=~: Increase size
+2. ~C-x C--~: Decrease size
+3. ~C-x C-0~: Restore defaults
 
 *** Jumping to links (link-hints)
 In order to visit a link, one never has to remove their fingers from

--- a/next/source/base.lisp
+++ b/next/source/base.lisp
@@ -13,7 +13,7 @@
   (interface:start)
   ;; create the default buffers
   (setf *minibuffer*
-	(make-instance 'buffer :name "minibuffer" :mode (minibuffer-mode)))
+        (make-instance 'buffer :name "minibuffer" :mode (minibuffer-mode)))
   (set-visible-active-buffer (generate-new-buffer "default" (document-mode)))
   (set-url *start-page-url*))
 
@@ -56,6 +56,12 @@
     #'scroll-up)
   (define-key *document-mode-map* (kbd "C-n")
     #'scroll-down)
+  (define-key *document-mode-map* (kbd "C-x C-=")
+    #'zoom-in-page)
+  (define-key *document-mode-map* (kbd "C-x C--")
+    #'zoom-out-page)
+  (define-key *document-mode-map* (kbd "C-x C-0")
+    #'unzoom-page)
   (define-key *document-mode-map* (kbd "C-l")
     (:input-complete *minibuffer* set-url history-typed-complete :setup #'setup-url :empty-complete t))
   (define-key *document-mode-map* (kbd "S-b o")

--- a/next/source/base.lisp
+++ b/next/source/base.lisp
@@ -31,7 +31,7 @@
   (define-key *minibuffer-mode-map* (kbd "")
     #'(lambda () (return-input (mode *minibuffer*))))
   (define-key *minibuffer-mode-map* (kbd "C-")
-    #'(lambda () (return-immediate (mode *minibuffer*))))  
+    #'(lambda () (return-immediate (mode *minibuffer*))))
   (define-key *minibuffer-mode-map* (kbd "C-g")
     #'(lambda () (cancel-input (mode *minibuffer*))))
   (define-key *minibuffer-mode-map* (kbd "Escape")
@@ -48,8 +48,10 @@
     (:input *minibuffer* go-anchor-new-buffer-focus :setup #'setup-anchor))
   (define-key *document-mode-map* (kbd "C-f")
     #'history-forwards)
+    ;; #'scroll-right)
   (define-key *document-mode-map* (kbd "C-b")
     #'history-backwards)
+    ;; #'scroll-left)
   (define-key *document-mode-map* (kbd "C-p")
     #'scroll-up)
   (define-key *document-mode-map* (kbd "C-n")

--- a/next/source/document-mode.lisp
+++ b/next/source/document-mode.lisp
@@ -14,6 +14,12 @@
 (defparenstatic scroll-up
     (ps:chain window (scroll-by 0 (ps:lisp (- *scroll-distance*)))))
 
+(defparenstatic scroll-left
+    (ps:chain window (scroll-by (ps:lisp (- *hl-scroll-distance*)) 0)))
+
+(defparenstatic scroll-right
+    (ps:chain window (scroll-by (ps:lisp *hl-scroll-distance*) 0)))
+
 (defun history-backwards ()
   ;; move up to parent node to iterate backwards in history tree
   (let ((parent (node-parent (active-history-node (mode *active-buffer*)))))

--- a/next/source/document-mode.lisp
+++ b/next/source/document-mode.lisp
@@ -20,6 +20,35 @@
 (defparenstatic scroll-right
     (ps:chain window (scroll-by (ps:lisp *hl-scroll-distance*) 0)))
 
+(defun ensure-zoom-ratio-range (zoom)
+  (let ((ratio (funcall zoom *current-zoom-ratio* *zoom-ratio-step*)))
+    (setf ratio (max ratio *zoom-ratio-min*))
+    (setf ratio (min ratio *zoom-ratio-max*))
+    (setf *current-zoom-ratio* ratio)))
+
+(defparen %zoom-in-page ()
+  (ps:lisp (ensure-zoom-ratio-range #'+))
+  (ps:let ((style (ps:chain document body style)))
+    (setf (ps:@ style zoom) (ps:lisp *current-zoom-ratio*))))
+
+(defun zoom-in-page ()
+  (interface:web-view-execute (view *active-buffer*) (%zoom-in-page)))
+
+(defparen %zoom-out-page ()
+  (ps:lisp (ensure-zoom-ratio-range #'-))
+  (ps:let ((style (ps:chain document body style)))
+    (setf (ps:@ style zoom) (ps:lisp *current-zoom-ratio*))))
+
+(defun zoom-out-page ()
+  (interface:web-view-execute (view *active-buffer*) (%zoom-out-page)))
+
+(defparen %unzoom-page ()
+  (ps:lisp (setf *current-zoom-ratio* *zoom-ratio-default*))
+  (setf (ps:chain document body style zoom) (ps:lisp *zoom-ratio-default*)))
+
+(defun unzoom-page ()
+  (interface:web-view-execute (view *active-buffer*) (%unzoom-page)))
+
 (defun history-backwards ()
   ;; move up to parent node to iterate backwards in history tree
   (let ((parent (node-parent (active-history-node (mode *active-buffer*)))))

--- a/next/source/global.lisp
+++ b/next/source/global.lisp
@@ -15,6 +15,11 @@
 (defvar *hl-scroll-distance* 50
   "Horizontal scroll distance. The distance scroll-left or scroll-right
   will scroll.")
+(defvar *current-zoom-ratio* 1.0)
+(defvar *zoom-ratio-step* 0.2)
+(defvar *zoom-ratio-min* 0.2)
+(defvar *zoom-ratio-max* 5.0)
+(defvar *zoom-ratio-default* 1.0)
 (defvar *swank-port* 4006
   "The port that swank will open a new server on (default Emacs slime port
   is 4005, default set to 4006 in nEXT to avoid collisions).")

--- a/next/source/global.lisp
+++ b/next/source/global.lisp
@@ -12,6 +12,9 @@
   "A list of all existing buffers.")
 (defvar *scroll-distance* 50
   "The distance scroll-down or scroll-up will scroll.")
+(defvar *hl-scroll-distance* 50
+  "Horizontal scroll distance. The distance scroll-left or scroll-right
+  will scroll.")
 (defvar *swank-port* 4006
   "The port that swank will open a new server on (default Emacs slime port
   is 4005, default set to 4006 in nEXT to avoid collisions).")

--- a/next/source/keymap.lisp
+++ b/next/source/keymap.lisp
@@ -83,12 +83,18 @@
     ;; Iterate through all key chords (space delimited)
     (loop for key-chord-string in (cl-strings:split key-sequence-string " ")
        ;; Iterate through all keys in chord (hyphen delimited)
-       do (let ((key-chord (make-key)))
-  	    (loop for key-character-string in (cl-strings:split key-chord-string "-")
-  	       do (cond
-  		    ((equal "C" key-character-string) (setf (key-control-modifier key-chord) t))
-		    ((equal "M" key-character-string) (setf (key-meta-modifier key-chord) t))
-		    ((equal "S" key-character-string) (setf (key-super-modifier key-chord) t))
-  		    (t (setf (key-character key-chord) key-character-string))))
-  	    (push key-chord key-sequence)))
+       do (let ((key-chord (make-key))
+                ;; KLUDGE: replace "--" with "- " to make `kbd` recognize key chords like
+                ;; "C--". Space characters were eliminated by the outer loop, so it should
+                ;; be safe to use
+                (key-chord-string (cl-strings:replace-all key-chord-string "--" "- ")))
+            (loop for key-character-string in (cl-strings:split key-chord-string "-")
+               do (cond
+                    ((equal "C" key-character-string) (setf (key-control-modifier key-chord) t))
+                    ((equal "M" key-character-string) (setf (key-meta-modifier key-chord) t))
+                    ((equal "S" key-character-string) (setf (key-super-modifier key-chord) t))
+                    ;; KLUDGE: make `kbd` recognize "C-x C--"
+                    ((equal " " key-character-string) (setf (key-character key-chord) "-"))
+                    (t (setf (key-character key-chord) key-character-string))))
+            (push key-chord key-sequence)))
     key-sequence))


### PR DESCRIPTION
1. horizontal scrolling and page zooming functionality
Some webpages (like github) don't fit nEXT horizontally (for me at least), add
horizontal scrolling and page zooming functionality to make life easier

2. a workaround solution to make `kbd` recognize `C-x C--`