### PR TITLE
Make calls into main-loop synchronous

### DIFF
--- a/next/next.asd
+++ b/next/next.asd
@@ -38,6 +38,6 @@
   :components ((:file "cocoa/application")))
 
 (defsystem :next/gtk
-  :depends-on (:next :cl-cffi-gtk :cl-webkit2)
+  :depends-on (:next :cl-cffi-gtk :cl-webkit2 :lparallel)
   :pathname "source/"
   :components ((:file "gtk/gtk")))


### PR DESCRIPTION
This should reduce the impedence mismatch between gtk and cocoa a bit.

It also allows one to get meaningful values out of expressions evaluated
in the main loop