### PR TITLE
save history on load start instead of completion

### DIFF
--- a/next/source/cocoa/cocoa.lisp
+++ b/next/source/cocoa/cocoa.lisp
@@ -100,7 +100,7 @@
   ((load-finished-callback :accessor load-finished-callback))
   (:metaclass ns:+ns-object))
 
-(objc:defmethod (#/webView:didFinishLoadForFrame: :void)
+(objc:defmethod (#/webView:didCommitLoadForFrame: :void)
     ((self next-web-view)
      (wvs :id)
      (fl :id))


### PR DESCRIPTION
Fixes #54.

Great to get a build environment up and running, hope to be able to contribute some more significant patches in the future to this fantastic browser.