### PR TITLE
store char-code in struct instead of key

### DIFF
--- a/next/source/cocoa/cocoa.lisp
+++ b/next/source/cocoa/cocoa.lisp
@@ -4,7 +4,6 @@
 
 (defparameter *window* nil)
 (defparameter *next-view* nil)
-(defparameter *character-conversion-table* (make-hash-table :test 'equalp))
 
 (defclass minibuffer-view (ns:ns-view)
   ((input-buffer :accessor input-buffer)
@@ -164,17 +163,17 @@
 (defun process-event (event)
   (let* ((flags (#/modifierFlags event))
 	 (character (ns-to-lisp-string (#/charactersIgnoringModifiers event)))
-         (mapped-character (gethash character *character-conversion-table* character)))
+         (key-code (char-code (char character 0))))
     (next:push-key-chord
      (> (logand flags #$NSControlKeyMask) 0)
      (> (logand flags #$NSAlternateKeyMask) 0)
      (> (logand flags #$NSCommandKeyMask) 0)
-     mapped-character)))
+     key-code)))
 
 (defun make-window ()
   (gui::assume-cocoa-thread)
   (ns:with-ns-rect (r 100.0 100.0 1024.0 768.0)
-    (ccl::with-autorelease-pool 
+    (ccl::with-autorelease-pool
       (let* ((.window. (make-instance
 		      'next-window
 		      :with-content-rect r
@@ -192,9 +191,7 @@
 	(setf *next-view* .next-view.)
 	*window*))))
 
-(defun initialize ()
-  (setf (gethash "" *character-conversion-table*) "RETURN")
-  (setf (gethash "-" *character-conversion-table*) "HYPHEN"))
+(defun initialize ())
 
 (defun start ()
   (on-main-thread

--- a/next/source/gtk/gtk.lisp
+++ b/next/source/gtk/gtk.lisp
@@ -5,7 +5,6 @@
 (defparameter *cookie-type* :webkit-cookie-persistent-storage-text)
 (defparameter *cookie-accept-policy* :webkit-cookie-policy-accept-always)
 (defparameter *next-interface* nil)
-(defparameter *character-conversion-table* (make-hash-table :test 'equalp))
 
 (defclass next-interface ()
   ((window :accessor window :initarg :window)
@@ -71,9 +70,7 @@
 	       (funcall ,thunk)))
 	   (lparallel:force ,promise))))))
 
-(defun initialize ()
-  (setf (gethash #\Return *character-conversion-table*) "RETURN")
-  (setf (gethash #\- *character-conversion-table*) "HYPHEN"))
+(defun initialize ())
 
 (defun start ()
   (synchronous-within-main
@@ -156,13 +153,13 @@
 (defun process-event (event)
   (let* ((modifier-state (gdk:gdk-event-key-state event))
          (character (gdk:gdk-keyval-to-unicode (gdk:gdk-event-key-keyval event)))
-         (mapped-character (gethash character *character-conversion-table* character)))
+         (key-code (char-code character)))
     (unless (equalp character #\Null)
       (next:push-key-chord
        (member :control-mask modifier-state :test #'equalp)
        (member :mod1-mask modifier-state :test #'equalp)
        (member :super-mask modifier-state :test #'equalp)
-       (string mapped-character)))))
+       (string key-code)))))
 
 (defun set-visible-view (view)
   (synchronous-within-main

--- a/next/source/keymap.lisp
+++ b/next/source/keymap.lisp
@@ -21,6 +21,22 @@
   meta-modifier
   super-modifier)
 
+(defvar *character-conversion-table* (make-hash-table :test 'equalp))
+(setf (gethash "RETURN" *character-conversion-table*) (char-code #\Return))
+(setf (gethash "HYPHEN" *character-conversion-table*) (char-code #\-))
+(setf (gethash "ESCAPE" *character-conversion-table*) 27) ;; 27 is ascii for esc
+
+(defun get-char-code (char-string)
+  ;; Take a string that represents a character and convert it into
+  ;; key code representing it.
+  ;; If the char-string does not represent a single character; returns nil
+  (let ((character-code (gethash char-string *character-conversion-table* nil))
+	(single-char? (= (length char-string) 1)))
+    (cond
+      (character-code character-code)
+      (single-char? (char-code (char char-string 0)))
+      (t ()))))
+
 (defun push-key-chord (control-modifier meta-modifier super-modifier key)
   ;; Adds a new chord to key-sequence
   ;; For example, it may add C-M-s or C-x

--- a/next/source/keymap.lisp
+++ b/next/source/keymap.lisp
@@ -16,7 +16,7 @@
 
 ;; A struct used to describe a key-chord
 (defstruct key
-  character
+  character-code
   control-modifier
   meta-modifier
   super-modifier)
@@ -49,7 +49,7 @@
       (setf (key-meta-modifier key-chord) t))
     (when super-modifier
       (setf (key-super-modifier key-chord) t))
-    (setf (key-character key-chord) key)
+    (setf (key-character-code key-chord) (get-char-code key))
     (push key-chord *key-sequence-stack*))
   (consume-key-sequence))
 
@@ -81,11 +81,27 @@
   ;; consume the stack, so that a sequence of keys
   ;; longer than one key-chord can be recorded
   (setf (gethash key-sequence mode-map) function)
-  ;; generate prefix representations
-  (loop while key-sequence
-     do
-       (pop key-sequence)
-       (setf (gethash key-sequence mode-map) "prefix")))
+  ;; set prefixes (suffixes of reversed list) to "prefix"
+  (maplist #'(lambda (key-seq) (setf (gethash (cdr key-seq) mode-map) "prefix"))
+	   (reverse key-sequence)))
+
+(defun split-chord (chord-string)
+  ;; Take a sequnce like "C-x" or "C-HYPHEN" and convert it into a
+  ;; key struct. The symbol after the last - should be either a literal
+  ;; character or a sequence characters describing a key code.
+  ;; We need to treat the last element of the sequence specially in
+  ;; order to have "C-C" be control C.
+  (let ((chord-seq (reverse (cl-strings:split chord-string "-")))
+	(key (make-key)))
+    ;; first get the character code for the last element of the chord string
+    (setf (key-character-code key) (get-char-code (car chord-seq)))
+    ;; then set the modifiers from the prefix of the chord string
+    (loop for modifier-string in (cdr chord-seq) do
+      (cond
+	((equal "C" modifier-string) (setf (key-control-modifier key) t))
+	((equal "M" modifier-string) (setf (key-meta-modifier key) t))
+	((equal "S" modifier-string) (setf (key-super-modifier key) t))))
+    key))
 
 (defun kbd (key-sequence-string)
   ;; Take a key-sequence-string in the form of "C-x C-s"
@@ -95,16 +111,4 @@
   ;; that describes the chord. We now have two "keys"
   ;; connect these two keys in a list <key> C-x, <key> C-s
   ;; this is will serve as the key to our key->function map
-  (let ((key-sequence ()))
-    ;; Iterate through all key chords (space delimited)
-    (loop for key-chord-string in (cl-strings:split key-sequence-string " ")
-       ;; Iterate through all keys in chord (hyphen delimited)
-       do (let ((key-chord (make-key)))
-  	    (loop for key-character-string in (cl-strings:split key-chord-string "-")
-  	       do (cond
-  		    ((equal "C" key-character-string) (setf (key-control-modifier key-chord) t))
-		    ((equal "M" key-character-string) (setf (key-meta-modifier key-chord) t))
-		    ((equal "S" key-character-string) (setf (key-super-modifier key-chord) t))
-  		    (t (setf (key-character key-chord) key-character-string))))
-  	    (push key-chord key-sequence)))
-    key-sequence))
+  (mapcar #'split-chord (cl-strings:split key-sequence-string " ")))

--- a/next/source/keymap.lisp
+++ b/next/source/keymap.lisp
@@ -37,7 +37,7 @@
       (single-char? (char-code (char char-string 0)))
       (t ()))))
 
-(defun push-key-chord (control-modifier meta-modifier super-modifier key)
+(defun push-key-chord (control-modifier meta-modifier super-modifier key-code)
   ;; Adds a new chord to key-sequence
   ;; For example, it may add C-M-s or C-x
   ;; to a stack which will be consumed by
@@ -49,7 +49,7 @@
       (setf (key-meta-modifier key-chord) t))
     (when super-modifier
       (setf (key-super-modifier key-chord) t))
-    (setf (key-character-code key-chord) (get-char-code key))
+    (setf (key-character-code key-chord) key-code)
     (push key-chord *key-sequence-stack*))
   (consume-key-sequence))
 


### PR DESCRIPTION
Because `'equalp` compares strings and characters case insensitively we
need to store the key code in the key struct used for key recognition.

This implements the changes suggested in #58.