### PR TITLE
Use the xdg home directory specification for configuration and data files

### DIFF
--- a/next/source/base.lisp
+++ b/next/source/base.lisp
@@ -3,7 +3,7 @@
 (in-package :next)
 
 (defun start ()
-  (ensure-directories-exist (uiop:physicalize-pathname "~/.next.d/"))
+  (ensure-directories-exist (xdg-data-home))
   (initialize-default-key-bindings)
   ;; load the user configuration if it exists
   (load *init-file-path* :if-does-not-exist nil)

--- a/next/source/global.lisp
+++ b/next/source/global.lisp
@@ -45,25 +45,16 @@
   "The package global variables available, populated by helper
   function load package-globals")
 (defvar *init-file-path*
-  (if (uiop:file-exists-p "~/.next.d/init.lisp")
-    "~/.next.d/init.lisp"
-    (xdg-config-home "init.lisp"))
+  (xdg-config-home "init.lisp")
   "The path where the system will look to load an init file from.")
 (defvar *history-db-path*
-  (if (uiop:file-exists-p "~/.next.d/history.db")
-    "~/.next.d/history.db"
-    (xdg-data-home "history.db"))
+  (xdg-data-home "history.db")
   "The path where the system will create/save the history database.")
 (defvar *bookmark-db-path*
-  (if (uiop:file-exists-p "~/.next.d/bookmark.db")
-    "~/.next.d/bookmark.db"
-    (xdg-data-home "bookmark.db"))
+  (xdg-data-home "bookmark.db")
   "The path where the system will create/save the bookmark database.")
 (defvar *current-completions* ()
   "A global variable used to store current completions for a
   completion function that has a static list.")
-(defvar *cookie-path-dir*
-  (if (uiop:directory-exists-p "~/.next.d/")
-    "~/.next.d"
-    (xdg-data-home))
+(defvar *cookie-path-dir* (xdg-data-home)
   "The path for cookies in the GTK Version of nEXT")

--- a/next/source/global.lisp
+++ b/next/source/global.lisp
@@ -2,6 +2,14 @@
 
 (in-package :next)
 
+;; utility functions for getting paths from the xdg directory specification in
+;; a namespaced directory for next
+(defun xdg-data-home (&optional (rel ""))
+  (uiop:xdg-data-home (concatenate 'string "next/" rel)))
+
+(defun xdg-config-home (&optional (rel ""))
+  (uiop:xdg-config-home (concatenate 'string "next/" rel)))
+
 (defvar *global-map* (make-hash-table :test 'equalp)
   "A global key map, available in every mode/buffer.")
 (defvar *active-buffer* ()

--- a/next/source/global.lisp
+++ b/next/source/global.lisp
@@ -44,14 +44,26 @@
 (defvar *package-globals* nil
   "The package global variables available, populated by helper
   function load package-globals")
-(defvar *init-file-path* "~/.next.d/init.lisp"
+(defvar *init-file-path*
+  (if (uiop:file-exists-p "~/.next.d/init.lisp")
+    "~/.next.d/init.lisp"
+    (xdg-config-home "init.lisp"))
   "The path where the system will look to load an init file from.")
-(defvar *history-db-path* "~/.next.d/history.db"
+(defvar *history-db-path*
+  (if (uiop:file-exists-p "~/.next.d/history.db")
+    "~/.next.d/history.db"
+    (xdg-data-home "history.db"))
   "The path where the system will create/save the history database.")
-(defvar *bookmark-db-path* "~/.next.d/bookmark.db"
+(defvar *bookmark-db-path*
+  (if (uiop:file-exists-p "~/.next.d/bookmark.db")
+    "~/.next.d/bookmark.db"
+    (xdg-data-home "bookmark.db"))
   "The path where the system will create/save the bookmark database.")
 (defvar *current-completions* ()
   "A global variable used to store current completions for a
   completion function that has a static list.")
-(defvar *cookie-path-dir* "~/.next.d/"
+(defvar *cookie-path-dir*
+  (if (uiop:directory-exists-p "~/.next.d/")
+    "~/.next.d"
+    (xdg-data-home))
   "The path for cookies in the GTK Version of nEXT")


### PR DESCRIPTION
As requested in #29. In order to maintain backwards compatibility with older versions of the browser I check for the existence of the old files before changing the location they exist in the file system. This means that users will have to remove ~/.next.d for the changes to take effect.