### PR TITLE
Build a Linux binary with asdf:make

### DIFF
--- a/next/Makefile
+++ b/next/Makefile
@@ -1,0 +1,7 @@
+LISP?=sbcl
+
+build-gtk:
+	$(LISP) --load next.asd \
+		--eval '(ql:quickload :next/gtk)' \
+		--eval '(asdf:make :next/gtk)' \
+		--eval '(quit)'

--- a/next/README.org
+++ b/next/README.org
@@ -121,6 +121,13 @@ In a new Terminal execute the following:
 5. Execute ~(next:start)~ to open your first Next window.
 
 ** Compile
+*** Build a Linux binary
+
+: cd next/next
+: make build-gtk
+
+the compiled binary will be present in source/next-gtk.
+
 *** MacOS Compilation
 From the CCL Source directory, execute
 

--- a/next/next.asd
+++ b/next/next.asd
@@ -1,7 +1,7 @@
 ;;; -*- Mode: Lisp; Syntax: ANSI-Common-Lisp; Base: 10 -*-
 ;;; next.asd
 
-(defsystem :next
+(asdf:defsystem :next
   :serial t
   :depends-on (:alexandria :cl-strings :cl-string-match :puri
                :queues.simple-queue :sqlite :parenscript :cl-json :swank)
@@ -29,19 +29,25 @@
 	       (:file "hydra")
 	       (:file "base")))
 
-(defsystem :next/cocoa
+(asdf:defsystem :next/cocoa
   :depends-on (:next (:require "cocoa") (:require "webkit"))
   :pathname "source/"
   :components ((:file "cocoa/repl")
                (:file "cocoa/utility")
                (:file "cocoa/cocoa")))
 
-(defsystem :next/cocoa/application
+(asdf:defsystem :next/cocoa/application
   :depends-on (:next/cocoa)
   :pathname "source/"
   :components ((:file "cocoa/application")))
 
-(defsystem :next/gtk
+(asdf:defsystem :next/gtk
   :depends-on (:next :cl-cffi-gtk :cl-webkit2 :lparallel)
   :pathname "source/"
-  :components ((:file "gtk/gtk")))
+  :components ((:file "gtk/gtk"))
+
+  ;; build executable
+  :build-operation "program-op"
+  ;; built in source/next-gtk
+  :build-pathname "next-gtk"
+  :entry-point "next:start")


### PR DESCRIPTION
Hello,

I've been able to build a linux binary (following the awesome Cookbook ;) https://lispcookbook.github.io/cl-cookbook/scripting.html#with-asdf)

Things to note/discuss:

- you're using `make.lisp` for MacOS, shall we harmonize the process somehow ?
- the compiled binary goes to `source/next-gtk`, should be trivial to change (also, what binary name ?)
- closing Next doesn't kill the process, I have to force `kill` it.

The next easy step is to build it on CI, and I can do it on Gitlab CI if you wish (it's a powerful CI platform, I can't compare it to Circle and co, Gitlab recently added the possibility to have a Github repo and use their CI (which only needed to mirror the sources on Gitlab anyway) https://about.gitlab.com/features/github/).

Hope this helps for #76 & #78 .